### PR TITLE
FEATURE: add include check to force user to maintain include order

### DIFF
--- a/mapbox/boost_spirit_karma.hpp
+++ b/mapbox/boost_spirit_karma.hpp
@@ -5,10 +5,21 @@
 #ifndef MAPBOX_BOOST_SPIRIT_KARMA_HPP
 #define MAPBOX_BOOST_SPIRIT_KARMA_HPP
 
+
+#ifdef BOOST_SPIRIT_GENERATOR_JANUARY_13_2009_1002AM
+  #error "ERROR file must be included before boost spirit karma"
+#endif
+
+
 #include <mapbox/variant.hpp>
 
 namespace boost { using mapbox::util::get; }
 
 #include <mapbox/detail/boost_spirit_attributes.hpp>
+#include <boost/spirit/include/karma.hpp>
+
+#ifndef BOOST_SPIRIT_GENERATOR_JANUARY_13_2009_1002AM
+  #error "ERROR include guard for boost spirit karma has changed!"
+#endif
 
 #endif

--- a/mapbox/boost_spirit_qi.hpp
+++ b/mapbox/boost_spirit_qi.hpp
@@ -5,6 +5,11 @@
 #ifndef MAPBOX_BOOST_SPIRIT_QI_HPP
 #define MAPBOX_BOOST_SPIRIT_QI_HPP
 
+
+#ifdef BOOST_SPIRIT_PARSER_OCTOBER_16_2008_0254PM
+  #error "ERROR file must be included before boost spirit qi"
+#endif
+
 #include <mapbox/detail/boost_spirit_attributes.hpp>
 
 #include <boost/spirit/include/qi_alternative.hpp>
@@ -21,5 +26,10 @@ namespace boost { namespace spirit { namespace qi { namespace detail
     };
 }}}}
 
+
+#include <boost/spirit/include/qi.hpp>
+#ifndef BOOST_SPIRIT_PARSER_OCTOBER_16_2008_0254PM
+  #error "ERROR include guard for boost spirit qi has changed!"
+#endif
 
 #endif


### PR DESCRIPTION
Hey @daminetreg as we discussed, this will force the user to maintain include order.

I do the following, 
- if the base parser or generator include guard is already present ->error and stop compiling
- if there not there, do your stuff, the explicit include karma or qi because if you include youre header, you want qi or karma
- check if now the include guard is set, if not -> error because then the first check did not work either!

what do you say?
